### PR TITLE
Feature/hide version

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -117,4 +117,5 @@ bind_reverse_zones:
   #   ttl: 604800
 
 bind_slaves_group: bind-slaves
+bind_show_version: false
 bind_zones_dir: /etc/bind/zones

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -81,6 +81,8 @@ bind_manage_zones: false
 bind_masters_group: bind-masters
 bind_pri_domain_name: vagrant.local
 
+bind_recursion_enabled: true
+
 bind_reverse_zones:
   []
   # - zone: 192.168

--- a/templates/etc/bind/named.conf.options.j2
+++ b/templates/etc/bind/named.conf.options.j2
@@ -9,8 +9,10 @@ acl {{ acl['name'] }} {
 {% endif %}
 options {
     directory "/var/cache/bind";
-    recursion yes;
+    recursion {% if bind_recursion_enabled %}yes{% else %}no{% endif %};
+{% if bind_acls is defined and bind_acls|length %}
     allow-query { {% for item in bind_acls %}{{ item['name'] }};{% if not loop.last %} {% endif %}{% endfor %} };
+{% endif %}
 {% if bind_forwarding_server %}
     forwarders {
 {%   for item in bind_forwarders %}

--- a/templates/etc/bind/named.conf.options.j2
+++ b/templates/etc/bind/named.conf.options.j2
@@ -24,4 +24,7 @@ options {
     dnssec-validation auto;
     auth-nxdomain no;    # conform to RFC1035
     listen-on-v6 { any; };
+{% if bind_show_version == false %}
+    version none;
+{% endif %}
 };


### PR DESCRIPTION
Hi,
First, thank you for sharing this ansible role.
Second, I did two improvements to enforce security on bind server:
- option to disable recursion;
- option to hide bind version

If you execute the command below, you can get the server's version and O.S. type. Hiding bind version, not.
`dig +short -c chaos -t txt @[YOUR_DNS_SERVER] version.bind`

If you can approve this, I'd be glad to not have to maintain separate code for that.

Thank you,
Ronan